### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ so be warned, here be dragons.
 
 [![Dependency Status](https://gemnasium.com/jaapz/CryptsyPythonAPI.png)](https://gemnasium.com/jaapz/CryptsyPythonAPI)
 [![Build Status](https://api.travis-ci.org/jaapz/CryptsyPythonAPI.png)](https://travis-ci.org/jaapz/CryptsyPythonAPI)
-[![PyPI Version](https://pypip.in/v/Cryptsy/badge.png)](https://pypi.python.org/pypi/Cryptsy)
+[![PyPI Version](https://img.shields.io/pypi/v/Cryptsy.svg)](https://pypi.python.org/pypi/Cryptsy)
 [![Coverage Status](https://coveralls.io/repos/jaapz/CryptsyPythonAPI/badge.png?branch=develop)](https://coveralls.io/r/jaapz/CryptsyPythonAPI?branch=develop)
 
 Author's Note


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20cryptsy))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `cryptsy`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badge to use shields.io instead.